### PR TITLE
feat: add height preset 3 and 4 buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,15 @@ This integration relies on the uplift-ble Python package, which can be found on 
 
 > Note: When using this project, no other device can be connected to the desk or it will be undiscoverable. This means that the Uplift Desk app needs to be either disconnected or closed for this application to work.
 
-The integration currently provides 3 entities:
+The integration currently provides 5 entities:
 1. A sensor for the current height of the desk. This will update automatically as your desk is moving, though it is not instantaneous and should not be relied on for safety.
 2. A button to move the desk to its configured preset 1.
 3. A button to move the desk to its configured preset 2.
+4. A disabled-by-default button to move supported desks to configured preset 3.
+5. A disabled-by-default button to move supported desks to configured preset 4.
+
+Preset 3 and 4 buttons are currently limited to the verified `0x00FF` and
+`0xFE60` desk profiles.
 
 
 <!-- Getting Started -->

--- a/custom_components/uplift_desk/button.py
+++ b/custom_components/uplift_desk/button.py
@@ -24,10 +24,16 @@ async def async_setup_entry(
 ) -> None:
     """Set up the button platform."""
     _LOGGER.debug("Setting up button platform for desk %s", config_entry.runtime_data.desk_info)
-    async_add_entities([
+    buttons: list[ButtonEntity] = [
         UpliftDeskPreset1Button(config_entry.runtime_data),
         UpliftDeskPreset2Button(config_entry.runtime_data),
-    ])
+    ]
+    if config_entry.runtime_data.supports_extended_presets:
+        buttons.extend([
+            UpliftDeskPreset3Button(config_entry.runtime_data),
+            UpliftDeskPreset4Button(config_entry.runtime_data),
+        ])
+    async_add_entities(buttons)
 
 class UpliftDeskPreset1Button(
     CoordinatorEntity[UpliftDeskBluetoothCoordinator],
@@ -82,3 +88,59 @@ class UpliftDeskPreset2Button(
     async def async_press(self) -> None:
         """Handle the button press."""
         await self.coordinator.async_preset_2()
+
+class UpliftDeskPreset3Button(
+    CoordinatorEntity[UpliftDeskBluetoothCoordinator],
+    ButtonEntity):
+    """Representation of a preset 3 button."""
+
+    entity_description = ButtonEntityDescription(
+        key="desk_preset_3",
+        translation_key="desk_preset_3",
+        has_entity_name=True,
+        entity_registry_enabled_default=False,
+    )
+
+    def __init__(self, coordinator: UpliftDeskBluetoothCoordinator) -> None:
+        """Initialize the button."""
+        _LOGGER.debug("Initializing preset 3 button for desk %s", coordinator.desk_info)
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.desk_address}_{self.entity_description.key}"
+        _LOGGER.debug("Set preset 3 button UID to %s", self._attr_unique_id)
+
+    @property
+    def device_info(self):
+        """Return information to link this entity with the correct device."""
+        return {"identifiers": {(DOMAIN, self.coordinator.desk_address)}, "name": self.coordinator.desk_name}
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.async_preset_3()
+
+class UpliftDeskPreset4Button(
+    CoordinatorEntity[UpliftDeskBluetoothCoordinator],
+    ButtonEntity):
+    """Representation of a preset 4 button."""
+
+    entity_description = ButtonEntityDescription(
+        key="desk_preset_4",
+        translation_key="desk_preset_4",
+        has_entity_name=True,
+        entity_registry_enabled_default=False,
+    )
+
+    def __init__(self, coordinator: UpliftDeskBluetoothCoordinator) -> None:
+        """Initialize the button."""
+        _LOGGER.debug("Initializing preset 4 button for desk %s", coordinator.desk_info)
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.desk_address}_{self.entity_description.key}"
+        _LOGGER.debug("Set preset 4 button UID to %s", self._attr_unique_id)
+
+    @property
+    def device_info(self):
+        """Return information to link this entity with the correct device."""
+        return {"identifiers": {(DOMAIN, self.coordinator.desk_address)}, "name": self.coordinator.desk_name}
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        await self.coordinator.async_preset_4()

--- a/custom_components/uplift_desk/coordinator.py
+++ b/custom_components/uplift_desk/coordinator.py
@@ -7,7 +7,9 @@ import logging
 import asyncio
 
 from uplift_ble.desk_controller import DeskController
+from uplift_ble.desk_configs import DeskVariant
 from uplift_ble.desk_validator import DeskValidator
+from uplift_ble.models import DiscoveredDesk as ValidatedDesk
 from uplift_ble.desk_enums import (
     DeskEventType,
     DeskUnit,
@@ -43,6 +45,11 @@ from .models import DiscoveredDesk
 type Uplift_Desk_DeskConfigEntry = ConfigEntry[UpliftDeskBluetoothCoordinator]  # noqa: F821
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+_EXTENDED_PRESET_VARIANTS = {
+    DeskVariant.JIECANG_0x00FF,
+    DeskVariant.JIECANG_0xFE60,
+}
 
 def process_service_info(
     hass: HomeAssistant,
@@ -97,6 +104,7 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
         self._discovered_desk = DiscoveredDesk(name=config_entry.title, address=desk_ble_device.address)
         self._desk_ble_device = desk_ble_device
         self._desk = None
+        self._desk_variant: DeskVariant | None = None
 
     async def _get_desk_controller(self):
         _LOGGER.debug("Getting desk controller for %s", self.desk_info)
@@ -110,7 +118,8 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
 
             bleak_client_factory: Callable[..., BLEClientProtocol] = _generate_existing_client_factory(bleak_client)
             
-            validated_desk: DiscoveredDesk = await DeskValidator(bleak_client_factory).validate_device(self._discovered_desk, timeout=BLEAK_TIMEOUT_SECONDS)
+            validated_desk: ValidatedDesk = await DeskValidator(bleak_client_factory).validate_device(self._discovered_desk, timeout=BLEAK_TIMEOUT_SECONDS)
+            self._desk_variant = validated_desk.desk_config.desk_variant
 
             bleak_client = await establish_connection(
                 BleakClientWithServiceCache,
@@ -138,6 +147,10 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
     @property
     def is_connected(self):
         return self._desk is not None and self._desk.client is not None and self._desk.client.is_connected
+
+    @property
+    def supports_extended_presets(self):
+        return self._desk_variant in _EXTENDED_PRESET_VARIANTS
 
     async def async_connect(self):
         await (await self._get_desk_controller()).start()
@@ -172,6 +185,14 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
     async def async_preset_2(self):
         await self.async_wake()
         await (await self._get_desk_controller()).move_to_height_preset_2()
+
+    async def async_preset_3(self):
+        await self.async_wake()
+        await (await self._get_desk_controller()).move_to_height_preset_3()
+
+    async def async_preset_4(self):
+        await self.async_wake()
+        await (await self._get_desk_controller()).move_to_height_preset_4()
 
     async def async_wake(self):
         await (await self._get_desk_controller()).wake()

--- a/custom_components/uplift_desk/icons.json
+++ b/custom_components/uplift_desk/icons.json
@@ -11,6 +11,12 @@
             },
             "desk_preset_2":{
                 "default": "mdi:numeric-2-box-outline"
+            },
+            "desk_preset_3":{
+                "default": "mdi:numeric-3-box-outline"
+            },
+            "desk_preset_4":{
+                "default": "mdi:numeric-4-box-outline"
             }
         }
     }

--- a/custom_components/uplift_desk/manifest.json
+++ b/custom_components/uplift_desk/manifest.json
@@ -18,7 +18,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/Bennett-Wendorf/hass-uplift-desk/issues",
   "requirements": [
-    "uplift-ble==0.5.2"
+    "uplift-ble==0.7.0"
   ],
   "version": "2.0.0-beta.2"
 }

--- a/custom_components/uplift_desk/strings.json
+++ b/custom_components/uplift_desk/strings.json
@@ -47,5 +47,21 @@
         "device_not_found_error": {
             "message": "Could not find Uplift Desk with address {address}"
         }
+    },
+    "entity": {
+        "button": {
+            "desk_preset_1": {
+                "name": "Move to Preset 1"
+            },
+            "desk_preset_2": {
+                "name": "Move to Preset 2"
+            },
+            "desk_preset_3": {
+                "name": "Move to Preset 3"
+            },
+            "desk_preset_4": {
+                "name": "Move to Preset 4"
+            }
+        }
     }
 }

--- a/custom_components/uplift_desk/translations/en.json
+++ b/custom_components/uplift_desk/translations/en.json
@@ -55,6 +55,12 @@
             },
             "desk_preset_2": {
                 "name": "Move to Preset 2"
+            },
+            "desk_preset_3": {
+                "name": "Move to Preset 3"
+            },
+            "desk_preset_4": {
+                "name": "Move to Preset 4"
             }
         }
     }


### PR DESCRIPTION
## Summary

- update the integration to `uplift-ble==0.7.0`
- add Preset 3 and Preset 4 buttons using the released public controller methods
- expose the new buttons only for the verified service profiles `0x00FF` and `0xFE60`
- keep the new movement buttons disabled by default
- add matching numeric icons, translations, and README documentation

The underlying commands were added and hardware-validated in `librick/uplift-ble#53` and are included in `uplift-ble` v0.7.0.

## Validation

- `uv run python -m compileall -q custom_components`
- JSON parsing for component metadata and translations
- `git diff --check`
- verified the `uplift-ble==0.7.0` package exports both preset methods and the gated desk variants
- independent review found no blockers in this change

## Existing Validation Noise

Local hassfest reaches a pre-existing translation-schema error for `config.step.confirm.bluetooth_description` in the base branch. This PR does not add or modify that key. Scoped Ruff likewise reports no net-new diagnostics relative to `v2.0.0`.

Refs #9