### PR TITLE
feat: add configurable fallback height units

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ This is the easiest way to install HASS Uplift Desk. Click the button below to g
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Bennett-Wendorf&repository=hass-uplift-desk&category=integration)
 
+### Fallback Height Unit
+
+Most desks report their display units. If a desk does not, open the
+integration's configuration options and select a fallback of centimeters or
+inches matching the desk's keypad setting. Choose no fallback to leave height
+unknown until the desk reports its units. A unit reported by the desk always
+takes precedence over the fallback. Saving a changed option reloads the
+integration to apply it.
+
+Existing entries retain the previous centimeters behavior during upgrade. If
+the desk keypad displays inches, change the fallback option after upgrading.
+New entries start with no fallback. Changing this option does not change the
+keypad's units or move the desk.
+
 
 <!-- CONTRIBUTING -->
 ## Contributing

--- a/custom_components/uplift_desk/__init__.py
+++ b/custom_components/uplift_desk/__init__.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 import logging
 
-from .const import DOMAIN
+from .const import CONF_FALLBACK_UNIT, DOMAIN
+
+from uplift_ble.desk_enums import DeskUnit
 
 from bleak import BleakError
 
@@ -58,6 +60,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: Uplift_Desk_DeskConfigEn
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
     return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: Uplift_Desk_DeskConfigEntry) -> bool:
+    """Preserve the previous centimeters fallback for existing entries."""
+    if entry.version > 1:
+        return False
+    if entry.version == 1 and entry.minor_version < 2:
+        options = dict(entry.options)
+        options.setdefault(CONF_FALLBACK_UNIT, DeskUnit.CENTIMETERS.value)
+        hass.config_entries.async_update_entry(entry, options=options, minor_version=2)
+    return True
+
 
 async def async_unload_entry(hass: HomeAssistant, entry: Uplift_Desk_DeskConfigEntry) -> bool:
     """Unload a config entry."""

--- a/custom_components/uplift_desk/__init__.py
+++ b/custom_components/uplift_desk/__init__.py
@@ -58,8 +58,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: Uplift_Desk_DeskConfigEn
     _LOGGER.debug("Initializing Uplift Desk for desk %s: %s", entry.title, entry.data["address"])
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: Uplift_Desk_DeskConfigEntry) -> None:
+    """Reload the entry after its options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: Uplift_Desk_DeskConfigEntry) -> bool:

--- a/custom_components/uplift_desk/config_flow.py
+++ b/custom_components/uplift_desk/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlowWithReload,
+    OptionsFlow,
 )
 from homeassistant.core import callback
 from .const import (
@@ -88,7 +88,7 @@ class UpliftDeskConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> UpliftDeskOptionsFlow:
         """Return the options flow handler."""
-        return UpliftDeskOptionsFlow()
+        return UpliftDeskOptionsFlow(config_entry)
 
     async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak) -> ConfigFlowResult:
         """Handle a flow initialized by Bluetooth discovery."""
@@ -366,8 +366,12 @@ class UpliftDeskConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
 
-class UpliftDeskOptionsFlow(OptionsFlowWithReload):
+class UpliftDeskOptionsFlow(OptionsFlow):
     """Configure height interpretation when the desk does not report units."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Retain the entry for Home Assistant versions without config_entry."""
+        self._config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -375,7 +379,7 @@ class UpliftDeskOptionsFlow(OptionsFlowWithReload):
         """Show and save the fallback height unit."""
         if user_input is not None:
             return self.async_create_entry(
-                title="", data={**self.config_entry.options, **user_input}
+                title="", data={**self._config_entry.options, **user_input}
             )
         return self.async_show_form(
             step_id="init",
@@ -383,7 +387,7 @@ class UpliftDeskOptionsFlow(OptionsFlowWithReload):
                 {
                     vol.Required(
                         CONF_FALLBACK_UNIT,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_FALLBACK_UNIT, FALLBACK_UNIT_NONE
                         ),
                     ): SelectSelector(

--- a/custom_components/uplift_desk/config_flow.py
+++ b/custom_components/uplift_desk/config_flow.py
@@ -1,12 +1,26 @@
 """Config flow for the Uplift Desk integration."""
 
+from __future__ import annotations
+
 import logging
 
 from uplift_ble.desk_controller import DeskController
 from uplift_ble.desk_validator import DeskValidator
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from .const import DOMAIN, BLEAK_TIMEOUT_SECONDS
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.core import callback
+from .const import (
+    DOMAIN,
+    BLEAK_TIMEOUT_SECONDS,
+    CONF_FALLBACK_UNIT,
+    FALLBACK_UNIT_NONE,
+)
+from uplift_ble.desk_enums import DeskUnit
 from .models import DiscoveredDesk
 
 from typing import Any
@@ -19,7 +33,12 @@ from homeassistant.components.bluetooth import (
 import re
 import voluptuous as vol
 
-from homeassistant.helpers.selector import selector
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    selector,
+)
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -53,7 +72,7 @@ class UpliftDeskConfigFlow(ConfigFlow, domain=DOMAIN):
     # The schema version of the entries that it creates
     # Home Assistant will call your migrate method if the version changes
     VERSION = 1
-    MINOR_VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -64,6 +83,12 @@ class UpliftDeskConfigFlow(ConfigFlow, domain=DOMAIN):
         ] = {}
         self._manual_address: str | None = None
         self._manual_name: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> UpliftDeskOptionsFlow:
+        """Return the options flow handler."""
+        return UpliftDeskOptionsFlow()
 
     async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak) -> ConfigFlowResult:
         """Handle a flow initialized by Bluetooth discovery."""
@@ -338,4 +363,40 @@ class UpliftDeskConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user_confirm",
             description_placeholders=placeholders,
+        )
+
+
+class UpliftDeskOptionsFlow(OptionsFlowWithReload):
+    """Configure height interpretation when the desk does not report units."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show and save the fallback height unit."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="", data={**self.config_entry.options, **user_input}
+            )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_FALLBACK_UNIT,
+                        default=self.config_entry.options.get(
+                            CONF_FALLBACK_UNIT, FALLBACK_UNIT_NONE
+                        ),
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                FALLBACK_UNIT_NONE,
+                                DeskUnit.CENTIMETERS.value,
+                                DeskUnit.INCHES.value,
+                            ],
+                            mode=SelectSelectorMode.DROPDOWN,
+                            translation_key="fallback_unit",
+                        )
+                    ),
+                }
+            ),
         )

--- a/custom_components/uplift_desk/const.py
+++ b/custom_components/uplift_desk/const.py
@@ -2,3 +2,6 @@
 
 DOMAIN = "uplift_desk"
 BLEAK_TIMEOUT_SECONDS = 15
+
+CONF_FALLBACK_UNIT = "fallback_unit"
+FALLBACK_UNIT_NONE = "none"

--- a/custom_components/uplift_desk/coordinator.py
+++ b/custom_components/uplift_desk/coordinator.py
@@ -24,6 +24,7 @@ from uplift_ble.desk_enums import (
 from uplift_ble.models import DiscoveredDesk as ValidatedDesk
 
 from .models import DiscoveredDesk
+from .const import CONF_FALLBACK_UNIT, FALLBACK_UNIT_NONE
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -38,6 +39,17 @@ class UpliftDeskServicesError(BleakError):
 
 
 _RECONNECT_BACKOFF_SECONDS: tuple[int, ...] = (5, 10, 20, 30)
+
+
+def _parse_fallback_unit(value: str | None) -> DeskUnit | None:
+    """Parse an explicit fallback without guessing for invalid values."""
+    if value is None or value == FALLBACK_UNIT_NONE:
+        return None
+    try:
+        return DeskUnit(value)
+    except ValueError:
+        _LOGGER.warning("Ignoring invalid fallback unit: %s", value)
+        return None
 
 
 class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
@@ -56,6 +68,9 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
         self._discovered_desk = DiscoveredDesk(name=config_entry.title, address=desk_ble_device.address)
         self._desk_ble_device = desk_ble_device
         self._desk = None
+        self._fallback_unit = _parse_fallback_unit(
+            config_entry.options.get(CONF_FALLBACK_UNIT)
+        )
         self._desk_variant: DeskVariant | None = None
         self.height_mm: float | None = None
         self.keypad_display_units = None
@@ -218,7 +233,7 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
                     address=self.desk_address,
                     name=self.desk_name,
                     desk_config=desk_config,
-                ).create_controller(client)
+                ).create_controller(client, fallback_unit=self._fallback_unit)
                 controller.on(DeskEventType.HEIGHT, self._async_height_notify_callback)
                 await controller.start()  # EXACTLY ONCE, on the fresh controller
                 self._desk = controller
@@ -358,9 +373,11 @@ class UpliftDeskBluetoothCoordinator(DataUpdateCoordinator):
         await controller.request_units()
         retrieved_unit = controller.unit
         if retrieved_unit is None:
-            _LOGGER.warning("Could not retrieve units from desk, defaulting to centimeters")
-            retrieved_unit = DeskUnit.CENTIMETERS
-            controller._unit = DeskUnit.CENTIMETERS
+            retrieved_unit = self._fallback_unit
+            if retrieved_unit is None:
+                _LOGGER.warning("Desk did not report units and no fallback is configured")
+            else:
+                _LOGGER.warning("Desk did not report units; using configured %s fallback", retrieved_unit.value)
         self.keypad_display_units = retrieved_unit
         return self.keypad_display_units
 

--- a/custom_components/uplift_desk/strings.json
+++ b/custom_components/uplift_desk/strings.json
@@ -44,6 +44,28 @@
             "message": "Could not find Uplift Desk with address {address}"
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Desk options",
+                "data": {
+                    "fallback_unit": "Fallback height unit"
+                },
+                "data_description": {
+                    "fallback_unit": "Used only when the desk does not report its units. Match the desk's keypad setting. Choose no fallback to leave height unknown until units are reported. This does not change the keypad's units."
+                }
+            }
+        }
+    },
+    "selector": {
+        "fallback_unit": {
+            "options": {
+                "none": "No fallback",
+                "centimeters": "Centimeters",
+                "inches": "Inches"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "desk_height": {

--- a/custom_components/uplift_desk/translations/en.json
+++ b/custom_components/uplift_desk/translations/en.json
@@ -44,6 +44,28 @@
             "message": "Could not find Uplift Desk with address {address}"
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Desk options",
+                "data": {
+                    "fallback_unit": "Fallback height unit"
+                },
+                "data_description": {
+                    "fallback_unit": "Used only when the desk does not report its units. Match the desk's keypad setting. Choose no fallback to leave height unknown until units are reported. This does not change the keypad's units."
+                }
+            }
+        }
+    },
+    "selector": {
+        "fallback_unit": {
+            "options": {
+                "none": "No fallback",
+                "centimeters": "Centimeters",
+                "inches": "Inches"
+            }
+        }
+    },
     "entity": {
         "sensor": {
             "desk_height": {

--- a/tests/test_fallback_unit.py
+++ b/tests/test_fallback_unit.py
@@ -1,0 +1,206 @@
+"""Fallback options through the real HA flow manager and BLE controller."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from uplift_ble.desk_enums import DeskUnit
+
+from custom_components.uplift_desk import async_migrate_entry
+from custom_components.uplift_desk.const import CONF_FALLBACK_UNIT, FALLBACK_UNIT_NONE
+from custom_components.uplift_desk.coordinator import UpliftDeskBluetoothCoordinator
+from custom_components.uplift_desk.sensor import DeskHeightSensor
+
+from .conftest import DESK_ADDRESS, DESK_DOMAIN, DESK_NAME, wait_until
+from .test_notifications import make_height_packet, make_units_packet
+
+
+@pytest.fixture(autouse=True)
+def stub_bluetooth_setup(monkeypatch):
+    """Keep HA dependency loading from opening the host Bluetooth stack."""
+    monkeypatch.setattr(
+        "homeassistant.components.bluetooth.async_setup", AsyncMock(return_value=True)
+    )
+
+
+def make_entry(hass, *, options=None, minor_version=2, version=1):
+    entry = MockConfigEntry(
+        domain=DESK_DOMAIN,
+        title=DESK_NAME,
+        data={CONF_ADDRESS: DESK_ADDRESS},
+        options=options or {},
+        version=version,
+        minor_version=minor_version,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        ({}, {CONF_FALLBACK_UNIT: "centimeters"}),
+        ({"other": True}, {"other": True, CONF_FALLBACK_UNIT: "centimeters"}),
+        ({CONF_FALLBACK_UNIT: "none"}, {CONF_FALLBACK_UNIT: "none"}),
+        ({CONF_FALLBACK_UNIT: "inches"}, {CONF_FALLBACK_UNIT: "inches"}),
+    ],
+)
+async def test_migration_preserves_existing_options(hass, options, expected):
+    entry = make_entry(hass, options=options, minor_version=1)
+    assert await async_migrate_entry(hass, entry)
+    assert entry.options == expected
+    assert (entry.version, entry.minor_version) == (1, 2)
+    assert await async_migrate_entry(hass, entry)
+    assert entry.options == expected
+
+
+async def test_future_major_migration_is_rejected(hass):
+    entry = make_entry(hass, version=2)
+    assert not await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.options == {}
+
+
+@pytest.mark.parametrize("selection", ["none", "centimeters", "inches"])
+async def test_options_manager_saves_and_reloads(hass, selection):
+    initial = "inches" if selection != "inches" else "none"
+    entry = make_entry(hass, options={CONF_FALLBACK_UNIT: initial, "other": True})
+    with patch.object(hass.config_entries, "async_reload", AsyncMock(return_value=True)) as reload:
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["data_schema"]({}) == {CONF_FALLBACK_UNIT: initial}
+        with pytest.raises(vol.Invalid):
+            result["data_schema"]({CONF_FALLBACK_UNIT: "meters"})
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_FALLBACK_UNIT: selection}
+        )
+        await hass.async_block_till_done()
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert entry.options == {CONF_FALLBACK_UNIT: selection, "other": True}
+        reload.assert_awaited_once_with(entry.entry_id)
+
+
+async def test_unchanged_options_do_not_reload(hass):
+    entry = make_entry(hass, options={CONF_FALLBACK_UNIT: "centimeters"})
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload:
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_FALLBACK_UNIT: "centimeters"}
+        )
+        await hass.async_block_till_done()
+        reload.assert_not_awaited()
+
+
+@pytest.mark.parametrize("fallback", [None, "none", "centimeters", "inches", "invalid"])
+async def test_height_fallback_and_late_report(hass, fake_ble, fallback):
+    options = {} if fallback is None else {CONF_FALLBACK_UNIT: fallback}
+    entry = make_entry(hass, options=options)
+    coordinator = UpliftDeskBluetoothCoordinator(hass, entry, fake_ble.device)
+    client = fake_ble.valid_client()
+    fake_ble.queue_client(client)
+    try:
+        await coordinator.async_connect()
+        sensor = DeskHeightSensor(coordinator)
+        await coordinator.async_read_desk_units()
+        assert coordinator._desk.unit is None
+        await client.simulate_notification(make_height_packet(300))
+        # Process notifications even when no fallback means there is no HEIGHT event.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        expected = {"centimeters": 300.0, "inches": 762.0}.get(fallback)
+        assert coordinator.height_mm == expected
+        assert sensor.native_value == expected
+
+        # A later, conflicting real unit report reinterprets cached raw height.
+        reported_byte = 0 if fallback == "inches" else 1
+        expected = 300.0 if reported_byte == 0 else 762.0
+        await client.simulate_notification(make_units_packet(reported_byte))
+        await wait_until(lambda: sensor.native_value == expected)
+        assert await coordinator.async_read_desk_units() is (
+            DeskUnit.CENTIMETERS if reported_byte == 0 else DeskUnit.INCHES
+        )
+    finally:
+        await coordinator.async_disconnect()
+
+
+async def test_fallback_survives_replacement_controller(hass, fake_ble):
+    entry = make_entry(hass, options={CONF_FALLBACK_UNIT: "inches"})
+    coordinator = UpliftDeskBluetoothCoordinator(hass, entry, fake_ble.device)
+    first, second = fake_ble.valid_client(), fake_ble.valid_client()
+    fake_ble.queue_client(first)
+    fake_ble.queue_client(second)
+    try:
+        await coordinator.async_connect()
+        old = coordinator._desk
+        first.simulate_disconnect()
+        await wait_until(lambda: coordinator.is_connected and coordinator._desk.client is second)
+        assert coordinator._desk is not old
+        await second.simulate_notification(make_height_packet(300))
+        await wait_until(lambda: coordinator.height_mm == 762.0)
+        assert coordinator._desk.unit is None
+    finally:
+        await coordinator.async_disconnect()
+
+
+async def test_changed_options_reload_real_entry(hass, fake_ble):
+    """HA unloads the old controller and sets up the new option through its manager."""
+    entry = make_entry(hass, options={CONF_FALLBACK_UNIT: "centimeters"})
+    first, second = fake_ble.valid_client(), fake_ble.valid_client()
+    fake_ble.queue_client(first)
+    fake_ble.queue_client(second)
+    try:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert entry.state is ConfigEntryState.LOADED
+        old = entry.runtime_data
+        await first.simulate_notification(make_height_packet(300))
+        await wait_until(lambda: old.height_mm == 300.0)
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_FALLBACK_UNIT: "inches"}
+        )
+        await hass.async_block_till_done()
+        assert entry.state is ConfigEntryState.LOADED
+        assert entry.runtime_data is not old
+        assert not first.is_connected
+        assert entry.runtime_data._desk.client is second
+        await second.simulate_notification(make_height_packet(300))
+        await wait_until(lambda: entry.runtime_data.height_mm == 762.0)
+        assert entry.runtime_data._desk.unit is None
+    finally:
+        await hass.config_entries.async_unload(entry.entry_id)
+
+
+async def test_new_entry_has_no_fallback(hass, fake_ble, monkeypatch):
+    """The existing manual flow creates version 1.2 without an implicit unit."""
+    monkeypatch.setattr(
+        "custom_components.uplift_desk.config_flow.async_discovered_service_info",
+        lambda hass: [],
+    )
+    monkeypatch.setattr(
+        "custom_components.uplift_desk.config_flow.DeskValidator.validate_device",
+        AsyncMock(return_value=fake_ble.device),
+    )
+    with patch("custom_components.uplift_desk.async_setup_entry", AsyncMock(return_value=True)):
+        result = await hass.config_entries.flow.async_init(
+            DESK_DOMAIN, context={"source": "user"}
+        )
+        assert result["step_id"] == "user_manual"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_ADDRESS: DESK_ADDRESS, "name": DESK_NAME}
+        )
+        assert result["step_id"] == "user_confirm"
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
+        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    entry = result["result"]
+    assert (entry.version, entry.minor_version) == (1, 2)
+    assert await async_migrate_entry(hass, entry)
+    assert CONF_FALLBACK_UNIT not in entry.options
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["data_schema"]({}) == {CONF_FALLBACK_UNIT: FALLBACK_UNIT_NONE}

--- a/tests/test_fallback_unit.py
+++ b/tests/test_fallback_unit.py
@@ -67,9 +67,12 @@ async def test_future_major_migration_is_rejected(hass):
 
 
 @pytest.mark.parametrize("selection", ["none", "centimeters", "inches"])
-async def test_options_manager_saves_and_reloads(hass, selection):
+async def test_options_manager_saves_and_reloads(hass, fake_ble, selection):
     initial = "inches" if selection != "inches" else "none"
     entry = make_entry(hass, options={CONF_FALLBACK_UNIT: initial, "other": True})
+    fake_ble.queue_client(fake_ble.valid_client())
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
     with patch.object(hass.config_entries, "async_reload", AsyncMock(return_value=True)) as reload:
         result = await hass.config_entries.options.async_init(entry.entry_id)
         assert result["type"] is FlowResultType.FORM
@@ -83,10 +86,14 @@ async def test_options_manager_saves_and_reloads(hass, selection):
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert entry.options == {CONF_FALLBACK_UNIT: selection, "other": True}
         reload.assert_awaited_once_with(entry.entry_id)
+    await hass.config_entries.async_unload(entry.entry_id)
 
 
-async def test_unchanged_options_do_not_reload(hass):
+async def test_unchanged_options_do_not_reload(hass, fake_ble):
     entry = make_entry(hass, options={CONF_FALLBACK_UNIT: "centimeters"})
+    fake_ble.queue_client(fake_ble.valid_client())
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
     with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload:
         result = await hass.config_entries.options.async_init(entry.entry_id)
         await hass.config_entries.options.async_configure(
@@ -94,6 +101,7 @@ async def test_unchanged_options_do_not_reload(hass):
         )
         await hass.async_block_till_done()
         reload.assert_not_awaited()
+    await hass.config_entries.async_unload(entry.entry_id)
 
 
 @pytest.mark.parametrize("fallback", [None, "none", "centimeters", "inches", "invalid"])


### PR DESCRIPTION
Desks that do not report their display units currently fall back to centimeters, so a desk configured in inches can show an incorrect height. Add an integration option for no fallback, centimeters, or inches, using the public `fallback_unit` support released in [uplift-ble 0.7.0](https://github.com/librick/uplift-ble/pull/54).

Reported desk units always take precedence. Existing entries migrate with the previous centimeters fallback; new entries default to no fallback and leave height unknown until a unit is reported or a fallback is selected. Saving a changed option reloads the integration. The setting changes height interpretation, not the keypad's units or desk movement commands.

Validation: 48 pytest tests pass, including the merged reconnect regression tests and 17 fallback cases covering migration, options persistence/reload, conversion, late unit reports, and reconnect. Compileall and diff checks pass; official hassfest reports zero invalid integrations. Independent final review found no actionable issues. The branch includes current `v2.0.0` through merged #27, with its lifecycle locking and teardown behavior preserved. JetBrains inspection was inconclusive because the local worktree has no configured Python SDK. This revision has not been installed or tested on a physical desk.

Refs #26
